### PR TITLE
feat: add DocSearch as recommended by docusaurus.

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -15,14 +15,14 @@ module.exports = {
   favicon: 'img/favicon.ico',
   organizationName: 'neutronjs',
   projectName: 'neutron-cli',
-  algolia: {
-      apiKey: '7ff42c6bf2833e56fbabd0f4da10e002',
-      indexName: 'neutron',
-      algoliaOptions: {
-        facetFilters: [`version:${versions[0]}`],
-      },
-  },
   themeConfig: {
+    algolia: {
+    apiKey: '7ff42c6bf2833e56fbabd0f4da10e002',
+    indexName: 'neutron',
+    algoliaOptions: {
+      facetFilters: [`version:${versions[0]}`],
+    },
+    },
     navbar: {
       title: 'Neutron JS',
       logo: {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -17,8 +17,8 @@ module.exports = {
   projectName: 'neutron-cli',
   themeConfig: {
     algolia: {
-      apiKey: '7ff42c6bf2833e56fbabd0f4da10e002',
       indexName: 'neutron',
+      apiKey: '7ff42c6bf2833e56fbabd0f4da10e002',
     },
     navbar: {
       title: 'Neutron JS',

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -15,6 +15,13 @@ module.exports = {
   favicon: 'img/favicon.ico',
   organizationName: 'neutronjs',
   projectName: 'neutron-cli',
+  algolia: {
+      apiKey: '7ff42c6bf2833e56fbabd0f4da10e002',
+      indexName: 'neutron',
+      algoliaOptions: {
+        facetFilters: [`version:${versions[0]}`],
+      },
+  },
   themeConfig: {
     navbar: {
       title: 'Neutron JS',

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -17,11 +17,8 @@ module.exports = {
   projectName: 'neutron-cli',
   themeConfig: {
     algolia: {
-    apiKey: '7ff42c6bf2833e56fbabd0f4da10e002',
-    indexName: 'neutron',
-    algoliaOptions: {
-      facetFilters: [`version:${versions[0]}`],
-    },
+      apiKey: '7ff42c6bf2833e56fbabd0f4da10e002',
+      indexName: 'neutron',
     },
     navbar: {
       title: 'Neutron JS',


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.